### PR TITLE
Workflow runner CLI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- CLI `run-workflow` dropped an `s` from `json.loads`, and the help text on the
+  timout argument was
+  incorrect. ([#5](https://github.com/cirrus-geo/cirrus-mgmt/pull/5)
+
 ## [v0.1.0] - 2023-08-01
 
 ### Added

--- a/src/cirrus/plugins/management/commands/manage.py
+++ b/src/cirrus/plugins/management/commands/manage.py
@@ -124,7 +124,7 @@ def refresh(deployment, stackname=None, profile=None):
     "--poll-interval",
     type=int,
     default=WORKFLOW_POLL_INTERVAL,
-    help="Maximum time (seconds) to allow for the workflow to complete",
+    help="Time (seconds) to dwell between polling for workflow status",
 )
 @raw_option
 @pass_deployment

--- a/src/cirrus/plugins/management/commands/manage.py
+++ b/src/cirrus/plugins/management/commands/manage.py
@@ -131,7 +131,7 @@ def refresh(deployment, stackname=None, profile=None):
 def run_workflow(deployment, timeout, raw, poll_interval):
     """Pass a payload (from stdin) off to a deployment, wait for the workflow to finish,
     retrieve and return its output payload"""
-    payload = json.load(sys.stdin.read())
+    payload = json.loads(sys.stdin.read())
 
     output = deployment.run_workflow(
         payload=payload,


### PR DESCRIPTION
### Fixed
- CLI `run-workflow` dropped an `s` from `json.loads`, and the help text on the timout argument was incorrect.