### PR TITLE
fix sfn execution retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - CLI `run-workflow` dropped an `s` from `json.loads`, and the help text on the
   timout argument was
-  incorrect. ([#5](https://github.com/cirrus-geo/cirrus-mgmt/pull/5)
+  incorrect. ([#5](https://github.com/cirrus-geo/cirrus-mgmt/pull/5))
+- Return correct execution(`[-1]`), as new Step Function executions are
+  appended to the `executions` list, from the StateDB
+  Item. ([#6](https://github.com/cirrus-geo/cirrus-mgmt/pull/6))
 
 ## [v0.1.0] - 2023-08-01
 

--- a/src/cirrus/plugins/management/deployment.py
+++ b/src/cirrus/plugins/management/deployment.py
@@ -302,7 +302,7 @@ class Deployment(DeploymentMeta):
     def get_execution_by_payload_id(self, payload_id):
         execs = self.get_payload_state(payload_id).get("executions", [])
         try:
-            exec_arn = execs[0]
+            exec_arn = execs[-1]
         except IndexError:
             raise exceptions.NoExecutionsError(payload_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ except ImportError:
     EventDB = None
 
 from cirrus.core.project import Project
+from cirrus.lib2.process_payload import ProcessPayload, ProcessPayloads
 from cirrus.lib2.statedb import StateDB
 
 
@@ -225,3 +226,14 @@ def invoke(cli_runner):
         return cli_runner.invoke(cli, shlex.split(cmd), **kwargs)
 
     return _invoke
+
+
+@pytest.fixture
+def basic_payloads(fixtures):
+    return ProcessPayloads(
+        process_payloads=[
+            ProcessPayload(
+                json.loads(fixtures.joinpath("basic_payload.json").read_text())
+            )
+        ]
+    )

--- a/tests/fixtures/basic_payload.json
+++ b/tests/fixtures/basic_payload.json
@@ -1,0 +1,41 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": "dummy-item",
+            "properties": {
+                "datetime": "1970-01-01T00:00:00Z",
+                "created": "1970-01-01T00:00:00Z",
+                "updated": "1970-01-01T00:00:00Z"
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": []
+            },
+            "links": [],
+            "assets": {},
+            "bbox": [],
+            "stac_extensions": [],
+            "collection": "dummy-collection"
+        }
+    ],
+    "process": {
+        "workflow": "workflow1",
+        "replace": true,
+        "upload_options": {
+            "path_template": "${collection}/${year}/${id}",
+            "collections": {
+                "mycollection": ".*"
+},
+            "s3_urls": true
+        },
+        "tasks": {
+            "task1": {
+                "param1": true
+            }
+        }
+    },
+    "id": "test/workflow-workflow1/test-item"
+}


### PR DESCRIPTION
StepFunctions executions are appended to the list stored in each StateDB item, so this modifies the code to grab the most recent execution.