### PR TITLE
Release v0.1.1

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,11 @@
+MD013:
+  line_length: 88
+  heading_line_length: 88
+  code_block_line_length: 100
+
+MD024:
+  siblings_only: true
+
+MD053:
+  ignored_definitions:
+    - "unreleased"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,10 @@ repos:
         language: system
         types: [text]
         stages: [commit, push, manual]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.38.0
+    hooks:
+    - id: markdownlint
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.1.1] - 2024-02-16
 
 ### Fixed
+
 - CLI `run-workflow` dropped an `s` from `json.loads`, and the help text on the
   timout argument was
   incorrect. ([#5](https://github.com/cirrus-geo/cirrus-mgmt/pull/5))
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release
 
-[unreleased]: https://github.com/cirrus-geo/cirrus-mgmt/compare/v0.1.0...main
+[unreleased]: https://github.com/cirrus-geo/cirrus-mgmt/compare/v0.1.1...main
+[v0.1.1]: https://github.com/cirrus-geo/cirrus-mgmt/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/cirrus-geo/cirrus-mgmt/compare/v0.1.0a...v0.1.0
 [v0.1.0a]: https://github.com/cirrus-geo/cirrus-mgmt/releases/tag/v0.1.0a

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pytest>=6.2
 pytest-cov>=2.9
 flake8>=5.0
-moto>=1.3.16
+moto>=1.3.16,<5
 black>=22.8
 isort>=5.10
 mypy>=0.981


### PR DESCRIPTION
Also adds pre-commit config for markdownlint.

## [v0.1.1] - 2024-02-16

### Fixed

- CLI `run-workflow` dropped an `s` from `json.loads`, and the help text on the
  timout argument was
  incorrect. ([#5](https://github.com/cirrus-geo/cirrus-mgmt/pull/5))
- Return correct execution(`[-1]`), as new Step Function executions are
  appended to the `executions` list, from the StateDB
  Item. ([#6](https://github.com/cirrus-geo/cirrus-mgmt/pull/6))
- Enable both `call` CLI to set exit status code based of `Deployment.call`,
  and exception raised from `subprocess.check_call` if used as a
  library. ([#7](https://github.com/cirrus-geo/cirrus-mgmt/pull/7)
